### PR TITLE
Исправлена ошибка сохранения текущей позиции в логах 1С

### DIFF
--- a/Apps/YY.EventLogExportToElasticSearch/Program.cs
+++ b/Apps/YY.EventLogExportToElasticSearch/Program.cs
@@ -44,6 +44,8 @@ namespace YY.EventLogExportToElasticSearch
             int maximumRetries = elasticSearchSection.GetValue<int>("MaximumRetries");
             int maxRetryTimeout = elasticSearchSection.GetValue<int>("MaxRetryTimeout");
 
+            IConfigurationSection applicationSection = Configuration.GetSection("Application");
+            bool waitAfterFinish = applicationSection.GetValue("WaitAfterFinish", false);
 
             if (string.IsNullOrEmpty(eventLogPath))
             {
@@ -102,8 +104,11 @@ namespace YY.EventLogExportToElasticSearch
 
             Console.WriteLine();
             Console.WriteLine();
-            Console.WriteLine("Для выхода нажмите любую клавишу...");
-            Console.Read();
+            if (waitAfterFinish)
+            {
+                Console.WriteLine("Для выхода нажмите любую клавишу...");
+                Console.Read();
+            }
         }
 
         #endregion

--- a/Libs/YY.EventLogExportAssistant.ElasticSearch/Helpers/ElasticSearchHelper.cs
+++ b/Libs/YY.EventLogExportAssistant.ElasticSearch/Helpers/ElasticSearchHelper.cs
@@ -109,9 +109,9 @@ namespace YY.EventLogExportAssistant.ElasticSearch.Helpers
             LogFileElement data,
             string indexName)
         {
-            var indexHistoryResponse = client.Index(data, idx => idx.Index(indexName.GetHistoryLogFilesIndexName()));
-            if (!indexHistoryResponse.ApiCall.Success)
-                throw indexHistoryResponse.ApiCall.OriginalException;
+            var indexActualResponse = client.Index(data, idx => idx.Index(indexName.GetActualLogFilesIndexName()));
+            if (!indexActualResponse.ApiCall.Success)
+                throw indexActualResponse.ApiCall.OriginalException;
         }
     }
 }

--- a/Libs/YY.EventLogExportAssistant.ElasticSearch/YY.EventLogExportAssistant.ElasticSearch.csproj
+++ b/Libs/YY.EventLogExportAssistant.ElasticSearch/YY.EventLogExportAssistant.ElasticSearch.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.0.30</Version>
+    <Version>1.0.0.31</Version>
     <Company>Permitin Yuriy</Company>
     <Authors>Permitin Yuriy</Authors>
     <Product>Event log export assistant to ElasticSearch</Product>
@@ -15,7 +15,8 @@
     <PackageTags>event, log, 1C, enterprise, export, elasticsearch, elk</PackageTags>
     <PackageReleaseNotes>Just beginning...</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.30</AssemblyVersion>
+    <AssemblyVersion>1.0.0.31</AssemblyVersion>
+    <FileVersion>1.0.0.31</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Добрый день!
Обнаружил ошибку при сохранении актуальной позиции в логе 1С. Вместо индекса actual запись производилась в индекс history. Как итог при перезапуске приложения парсинг лога начинался с самого начала.